### PR TITLE
[model]: mute actions are set, reducer value defaulted to true

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -17,6 +17,7 @@ export const types = {
   TIMER_EXPIRE: 'TIMER_EXPIRE',
   TIMER_RESET: 'TIMER_RESET',
   SET_ELAPSED_SECONDS: 'SET_ELAPSED_SECONDS',
+  MUTE_TOGGLE: 'MUTE_TOGGLE',
   // SET_REMAINING_SECONDS: 'SET_REMAINING_SECONDS',
 };
 
@@ -31,7 +32,7 @@ export const setSchedule = (schedule) => ({
 
 export const timerRollover = () => ({ type: types.TIMER_ROLLOVER });
 
-export const resetTimer = () => ({ type: types.TIMER_RESET});
+export const resetTimer = () => ({ type: types.TIMER_RESET });
 
 export const setCurrentRound = (round) => ({
   type: types.SET_CURRENT_ROUND,
@@ -86,6 +87,11 @@ const setStartTimeStamp = (stamp) => ({
 
 export const expireTimer = () => ({ type: types.TIMER_EXPIRE });
 
-export const setElapsedSeconds = (payload) => ({type: types.SET_ELAPSED_SECONDS, payload});
+export const setElapsedSeconds = (payload) => ({
+  type: types.SET_ELAPSED_SECONDS,
+  payload,
+});
 
 // export const setRemainingSeconds = (payload) => ({ type: types.SET_REMAINING_SECONDS, payload});
+
+export const toggleMute = () => ({ type: types.MUTE_TOGGLE });

--- a/src/components/TimeKeeperContainer/index.js
+++ b/src/components/TimeKeeperContainer/index.js
@@ -40,6 +40,7 @@ function TimeKeeperContainer(props) {
     expireTimer,
     resetTimer,
     status,
+    mute,
   } = props;
   const timerDebugControls = false;
   const [initialized, setInitialized] = useState(false);
@@ -61,14 +62,16 @@ function TimeKeeperContainer(props) {
 
   // either expire the timer or update elapsed seconds
   useEffect(() => {
-    // if start of round, play start sound
-    if (elapsedTime === 0 && status === STATUS.ROUND) {
-      startSound.play();
-    }
-    // play end sound at round expire
-    if (expired) {
-      if (status === STATUS.ROUND) {
-        endSound.play();
+    if (!mute) {
+      // if start of round, play start sound
+      if (elapsedTime === 0 && status === STATUS.ROUND) {
+        startSound.play();
+      }
+      // play end sound at round expire
+      if (expired) {
+        if (status === STATUS.ROUND) {
+          endSound.play();
+        }
       }
       expireTimer();
       setTimeout(timerRollover, 1000);
@@ -82,6 +85,7 @@ function TimeKeeperContainer(props) {
     setElapsedSeconds,
     status,
     expireTimer,
+    mute,
   ]);
 
   return (
@@ -104,13 +108,14 @@ function TimeKeeperContainer(props) {
 
 const mapStateToProps = (state) => {
   const {
-    basicReducer: { status, roundDuration, startTimeStamp, endTimeStamp },
+    basicReducer: { status, roundDuration, startTimeStamp, endTimeStamp, mute },
   } = state;
   return {
     status,
     endTimeStamp,
     roundDuration,
     startTimeStamp,
+    mute,
   };
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -126,6 +126,7 @@ const getInitialState = () => {
     endTimeStamp: undefined,
     timerDuration: undefined,
     completeRRCycle,
+    mute: true,
   };
 };
 
@@ -271,6 +272,11 @@ const basicReducer = (state = getInitialState(), action) => {
         ...state,
         elapsedSeconds: payload,
         remainingSeconds: isNaN(newRemaining) ? 0 : newRemaining,
+      };
+    case types.MUTE_TOGGLE:
+      return {
+        ...state,
+        mute: !state.mute,
       };
     default:
       return state;


### PR DESCRIPTION
`mute` is now a settable store value.  
it is defaulted to true.
there is currently no ui for this.